### PR TITLE
Fix `setState` calls

### DIFF
--- a/src/components/game.js
+++ b/src/components/game.js
@@ -41,12 +41,12 @@ class Game extends React.Component {
             updatedHistory = newHistoryEntry.concat(history);
         }
 
-        this.setState({
+        this.setState((prevState, props) => ({
             history: updatedHistory,
             stepNumber: history.length,
-            xIsNext: !this.state.xIsNext,
-            sortAsc: this.state.sortAsc,
-        });
+            xIsNext: !prevState.xIsNext,
+            sortAsc: prevState.sortAsc,
+        }));
     }
 
     jumpTo(step) {
@@ -79,12 +79,12 @@ class Game extends React.Component {
         else {
             history.sort((a, b) => a.moveNumber - b.moveNumber);
         }
-        this.setState({
+        this.setState((prevState, props) => ({
             history: history,
-            stepNumber: this.state.stepNumber,
-            xIsNext: this.state.xIsNext,
+            stepNumber: prevState.stepNumber,
+            xIsNext: prevState.xIsNext,
             sortAsc: !sortAsc,
-        });
+        }));
     }
 
     render() {


### PR DESCRIPTION
Because of the asynchronous nature of react’s batch updates calls to `setState`
should not rely on previous values of `state` nor `props`. Instead the function overload
should be used to receive previous values of `state` and `props`.

```
// Wrong
this.setState({
  counter: this.state.counter + this.props.increment,
});
```

```
// Correct
this.setState((prevState, props) => ({
  counter: prevState.counter + props.increment
}));
```